### PR TITLE
Added keyrings-alt

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -656,6 +656,24 @@ docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.link
 testing = ["pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
 
 [[package]]
+name = "keyrings-alt"
+version = "5.0.0"
+description = "Alternate keyring implementations"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "keyrings.alt-5.0.0-py3-none-any.whl", hash = "sha256:4b3fd67bbcdd5aa137e1537cc47b694dda134e290740918750a6a73bcf665b87"},
+    {file = "keyrings.alt-5.0.0.tar.gz", hash = "sha256:9d446cb47bbcea90ffa2ecc3e8003acf41573fc201bf44b4bf13bd0e11484828"},
+]
+
+[package.dependencies]
+"jaraco.classes" = "*"
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+testing = ["backports.unittest-mock", "gdata", "keyring (>=20)", "pycryptodome", "pycryptodomex", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-ruff", "python-keyczar"]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
@@ -1582,4 +1600,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "9c0343ea993ec1f766ef6cb1e12cb474dc11ce0f482a550dabe5770c2d2de1fb"
+content-hash = "584c11284743af67aaaca47c996b9ce11dd70f9dd158a87ba1c8068ace43e730"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ myst-parser = "^2.0.0"
 sphinx-autodoc2 = "^0.4.2"
 sphinx-rtd-theme = "^1.3.0"
 autodoc-pydantic = "^2.0.1"
+keyrings-alt = "^5.0.0"
 
 [tool.pytest.ini_options]
 pythonpath = "src"


### PR DESCRIPTION
In the RTD install, got the following error:

> keyring.errors.NoKeyringError: No recommended backend was available. Install a recommended 3rd party backend package; or, install the keyrings.alt package if you want to use the non-recommended backends. See https://pypi.org/project/keyring for details.

My *hopeful* solution is to add keyrings.alt package to the docs dependencies.